### PR TITLE
add ActiveJob::Trackable::Core

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,5 @@ gemspec
 
 # To use a debugger
 # gem 'byebug', group: [:development, :test]
+gem 'delayed_job_active_record'
 gem 'pry-byebug'

--- a/lib/activejob/trackable.rb
+++ b/lib/activejob/trackable.rb
@@ -2,10 +2,15 @@
 
 require 'activejob/trackable/railtie'
 require_relative './trackable/tracker'
+require_relative './trackable/core'
 
 module ActiveJob
-  # Extend ActiveJob with the ability to track (cancel, reschedule, etc) jobs
+  # Extend `ActiveJob::Base` with the ability to track (cancel, reschedule, etc) jobs
   module Trackable
-    # Your code goes here...
+    extend ActiveSupport::Concern
+
+    included do
+      include Core
+    end
   end
 end

--- a/lib/activejob/trackable/core.rb
+++ b/lib/activejob/trackable/core.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module ActiveJob
+  module Trackable
+    ##
+    # Extend `ActiveJob::Base` to automatically create a tracker for every enqueued jobs
+    #
+    # Tracker is only created if jobs is registered with a schedule (e.g by setting :wait options)
+    #
+    # Every Tracker will have their own `key`, which will be automatically generated from the
+    # related job class name and the arguments passed in to #perform_later. Trackers are expected
+    # to be unique by `key`.
+    #
+    # The default behaviour for generating key is quite minimalistic, so you might want to override
+    # it if you're passing non-simple-value arguments
+    #
+    # Example:
+    #
+    #   ```
+    #   class SampleJob < ActiveJob::Base
+    #     include ActiveJob::Trackable
+    #
+    #     def perform(one, two, three); end
+    #   end
+    #
+    #   # will generate tracker whose key = sample_job/foo/bar/1
+    #   SampleJob.set(wait: 1.day).perform_later('foo', 'bar', 1)
+    #   ```
+    #
+    module Core
+      extend ActiveSupport::Concern
+
+      included do
+        before_enqueue do
+          @tracker = nil
+        end
+
+        after_enqueue do |job|
+          next unless job.scheduled_at && job.provider_job_id
+
+          job.tracker.provider_job_id = job.provider_job_id
+          job.tracker.save!
+        end
+
+        after_perform do |job|
+          job.tracker&.destroy
+        end
+      end
+
+      def tracker
+        @tracker ||= Tracker.new key: key(*arguments)
+      end
+
+      private
+
+        def key(*arguments)
+          ([self.class.to_s.underscore] + arguments.map(&:to_s)).join('/')
+        end
+    end
+  end
+end

--- a/lib/generators/active_job/trackable/templates/migration.rb
+++ b/lib/generators/active_job/trackable/templates/migration.rb
@@ -4,7 +4,7 @@ class CreateActiveJobTrackers < ActiveRecord::Migration<%= migration_version %>
   def change
     create_table :active_job_trackers, force: true do |t|
       t.string :provider_job_id, index: true
-      t.string :key
+      t.string :key, index: { unique: true }
 
       t.timestamps
     end

--- a/test/activejob/trackable/base.rb
+++ b/test/activejob/trackable/base.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class ActiveJob::Trackable::BaseTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    ActiveJob::Base.disable_test_adapter
+    ActiveJob::Base.queue_adapter = :delayed_job
+  end
+
+  private
+
+    def assert_change(counter)
+      before = counter.call
+
+      yield
+
+      after = counter.call
+
+      refute_equal before, after
+    end
+
+    def refute_change(counter)
+      before = counter.call
+
+      yield
+
+      after = counter.call
+
+      assert_equal before, after
+    end
+end

--- a/test/activejob/trackable/core_test.rb
+++ b/test/activejob/trackable/core_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module ActiveJob::Trackable
+  class CoreTest < BaseTest
+    test 'enqueuing job creates new tracker' do
+      job = nil
+
+      assert_change -> { ActiveJob::Trackable::Tracker.count } do
+        job = described_class.set(wait: 1.day).perform_later('foo', 'bar')
+      end
+
+      assert_equal 'core_job/foo/bar', job.tracker.key
+    end
+
+    test 'enqueuing immediately running job does not creates tracker' do
+      refute_change -> { ActiveJob::Trackable::Tracker.count } do
+        described_class.perform_later 'foo', 'bar'
+      end
+    end
+
+    test 'enqueuing the same exact jobs multiple times should not be allowed' do
+      described_class.set(wait: 1.day).perform_later('foo', 'bar')
+
+      refute_change -> { ActiveJob::Trackable::Tracker.count } do
+        assert_raise ActiveRecord::RecordNotUnique do
+          described_class.set(wait: 1.day).perform_later('foo', 'bar')
+        end
+      end
+    end
+
+    test 'enqueuing the same jobs multiple times is allowed, as long as it generate different keys' do
+      bar_job = described_class.set(wait: 1.day).perform_later('foo', 'bar')
+
+      assert_nothing_raised do
+        baz_job = described_class.set(wait: 1.day).perform_later('foo', 'baz')
+
+        refute_equal bar_job.tracker.key, baz_job.tracker.key
+      end
+    end
+
+    test 'tracker is removed once the respective job is performed' do
+      job = described_class.set(wait: 1.day).perform_later('foo', 'bar')
+
+      assert_predicate job.tracker, :present?
+
+      job.perform_now
+
+      assert_raise ActiveRecord::RecordNotFound do
+        job.tracker.reload
+      end
+    end
+
+    private
+
+      def described_class
+        CoreJob
+      end
+  end
+end

--- a/test/dummy/app/jobs/core_job.rb
+++ b/test/dummy/app/jobs/core_job.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CoreJob < ApplicationJob
+  include ActiveJob::Trackable
+
+  def perform(*arguments); end
+end

--- a/test/dummy/bin/delayed_job
+++ b/test/dummy/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/test/dummy/db/migrate/20190214050719_create_active_job_trackers.rb
+++ b/test/dummy/db/migrate/20190214050719_create_active_job_trackers.rb
@@ -4,7 +4,7 @@ class CreateActiveJobTrackers < ActiveRecord::Migration[5.2]
   def change
     create_table :active_job_trackers, force: true do |t|
       t.string :provider_job_id, index: true
-      t.string :key
+      t.string :key, index: { unique: true }
 
       t.timestamps
     end

--- a/test/dummy/db/migrate/20190214082538_create_delayed_jobs.rb
+++ b/test/dummy/db/migrate/20190214082538_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration[5.2]
+  def self.up
+    create_table :delayed_jobs, force: true do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -17,6 +17,7 @@ ActiveRecord::Schema.define(version: 2019_02_14_082538) do
     t.string "key"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_active_job_trackers_on_key", unique: true
     t.index ["provider_job_id"], name: "index_active_job_trackers_on_provider_job_id"
   end
 

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_14_050719) do
+ActiveRecord::Schema.define(version: 2019_02_14_082538) do
 
   create_table "active_job_trackers", force: :cascade do |t|
     t.string "provider_job_id"
@@ -18,6 +18,21 @@ ActiveRecord::Schema.define(version: 2019_02_14_050719) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["provider_job_id"], name: "index_active_job_trackers_on_provider_job_id"
+  end
+
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,3 +22,5 @@ if ActiveSupport::TestCase.respond_to?(:fixture_path=)
   ActiveSupport::TestCase.file_fixture_path = ActiveSupport::TestCase.fixture_path + '/files'
   ActiveSupport::TestCase.fixtures :all
 end
+
+require_relative './activejob/trackable/base'


### PR DESCRIPTION
this class will provide the minimum functionality for managing trackers life time..

Tracker is only created if jobs is registered with a schedule (e.g by setting :wait options)

Every Tracker will have their own `key`, which will be automatically generated from the related job class name and the arguments passed in to #perform_later. Trackers are expected to be unique by `key`.

Example:

```rb
class SampleJob < ActiveJob::Base
  include ActiveJob::Trackable

  def perform(one, two, three); end
end

# will generate tracker whose key = sample_job/foo/bar/1
SampleJob.set(wait: 1.day).perform_later('foo', 'bar', 1)
```