### PR TITLE
allow throttling trackable jobs

### DIFF
--- a/lib/activejob/trackable.rb
+++ b/lib/activejob/trackable.rb
@@ -4,6 +4,7 @@ require 'activejob/trackable/railtie'
 require_relative './trackable/tracker'
 require_relative './trackable/core'
 require_relative './trackable/debounced'
+require_relative './trackable/throttled'
 
 module ActiveJob
   # Extend `ActiveJob::Base` with the ability to track (cancel, reschedule, etc) jobs

--- a/lib/activejob/trackable/throttled.rb
+++ b/lib/activejob/trackable/throttled.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module ActiveJob
+  module Trackable
+    ##
+    # Include `ActiveJob::Trackable::Throttled` to throttle scheduling job
+    # when multiple jobs with identical keys tried to be scheduled before
+    # it get performed
+    #
+    # Example:
+    #
+    #   ```
+    #   class SampleJob < ActiveJob::Base
+    #     include ActiveJob::Trackable::Throttled
+    #
+    #     trackable throttled: 1.day
+    #
+    #     def perform(one, two, three); end
+    #   end
+    #
+    #   # schedule a job to run 1.hour.from_now
+    #   SampleJob.set(wait: 1.hour).perform_later('foo', 'bar')
+    #
+    #   # less than 1 day later, trying to schedule the same job will silently fail
+    #   SampleJob.set(wait: 2.hour).perform_later('foo', 'bar')
+    #   ```
+    #
+    module Throttled
+      extend ActiveSupport::Concern
+
+      included do
+        include Core
+      end
+    end
+  end
+end

--- a/test/activejob/trackable/base.rb
+++ b/test/activejob/trackable/base.rb
@@ -23,8 +23,10 @@ class ActiveJob::Trackable::BaseTest < ActiveSupport::TestCase
     end
 
     def refute_job_enqueued
-      refute_change -> { Delayed::Job.count } do
-        yield
+      refute_tracked do
+        refute_change -> { Delayed::Job.count } do
+          yield
+        end
       end
     end
 

--- a/test/activejob/trackable/throttled_test.rb
+++ b/test/activejob/trackable/throttled_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module ActiveJob::Trackable
+  class ThrottledTest < BaseTest
+    attr_reader :now
+
+    setup do
+      Rails.cache.clear
+
+      @now = Time.current
+    end
+
+    test 'throttling job to not run more than once within certain period' do
+      travel_to now do
+        tracker = assert_tracked { schedule_job.tracker }
+        assert_equal 1.hour.from_now.to_f, tracker.job.scheduled_at
+
+        job_was = tracker.job
+        refute_job_enqueued do schedule_job end
+        assert_equal job_was.job_id, tracker.reload.job.job_id
+        assert_equal job_was.provider_job_id, tracker.reload.job.provider_job_id
+      end
+    end
+
+    test 'throttling with a longer period than the job schedule' do
+      tracker = travel_to(now) { assert_tracked { schedule_job.tracker } }
+
+      travel_to 1.hour.since(now) - 1.second do
+        refute_job_enqueued do schedule_job end
+        assert_equal 1.second.from_now.to_f, tracker.reload.job.scheduled_at
+      end
+
+      travel_to 1.hour.since(now) do
+        refute_job_enqueued do schedule_job end
+
+        tracker.job.perform_now
+
+        assert_raise ActiveRecord::RecordNotFound do
+          tracker.reload
+        end
+      end
+
+      travel_to 1.day.since(now) - 1.second do
+        refute_job_enqueued do schedule_job end
+      end
+
+      travel_to 1.day.since(now) do
+        assert_tracked do schedule_job end
+      end
+    end
+
+    private
+
+      def described_class
+        ThrottledJob
+      end
+
+      def schedule_job
+        described_class.set(wait: 1.hour).perform_later('foo')
+      end
+  end
+end

--- a/test/dummy/app/jobs/throttled_job.rb
+++ b/test/dummy/app/jobs/throttled_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ThrottledJob < ApplicationJob
+  include ActiveJob::Trackable::Throttled
+
+  trackable throttled: 1.day
+
+  def perform(*arguments); end
+end


### PR DESCRIPTION
for now, we're using Rails.cache for storing the throttling flag since it leads to a simpler implementation

we might want to investigate changing the tracker behavior to not get cleared when the job is performed, but after throttle period.. which might require us to register a tracker cleaning job for each scheduled trackable jobs?