### PR TITLE
bugfix: debounce and throttle should be usable side-by-side

### DIFF
--- a/test/activejob/trackable/throttled_debounced_test.rb
+++ b/test/activejob/trackable/throttled_debounced_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module ActiveJob::Trackable
+  class ThrottledDebouncedTest < BaseTest
+    attr_reader :now
+
+    setup do
+      Rails.cache.clear
+
+      @now = Time.current.at_beginning_of_hour
+    end
+
+    test 're-throttled when job are debounced' do
+      tracker = travel_to(now) { assert_tracked { schedule_job.tracker } }
+
+      travel_to 1.hour.since(now) do
+        refute_job_enqueued do schedule_job end
+      end
+      assert_equal 3.hour.since(now).to_f, tracker.reload.job.scheduled_at
+
+      travel_to 3.hour.since(now) do
+        tracker.job.perform_now
+
+        assert_raise ActiveRecord::RecordNotFound do
+          tracker.reload
+        end
+      end
+
+      travel_to 1.day.since(now) do
+        refute_job_enqueued do
+          schedule_job
+        end
+      end
+
+      travel_to 1.day.since(3.hour.since(now)) - 1.second do
+        refute_job_enqueued do schedule_job end
+      end
+
+      travel_to 1.day.since(3.hour.since(now)) do
+        assert_tracked do schedule_job end
+      end
+    end
+
+    test 'arguments is updated when job gets rescheduled' do
+      now = Time.current
+
+      tracker = travel_to(now) { schedule_job.tracker }
+      assert_equal %w[bar spicy], tracker.job.arguments
+
+      travel_to 1.hour.since(now) do
+        schedule_job('bar', 'sour')
+      end
+      assert_equal %w[bar sour], tracker.reload.job.arguments
+    end
+
+    private
+
+      def described_class
+        ThrottledDebouncedJob
+      end
+
+      def schedule_job(foo = 'bar', extra = 'spicy')
+        described_class.set(wait: 2.hour).perform_later(foo, extra)
+      end
+  end
+end

--- a/test/activejob/trackable/throttled_test.rb
+++ b/test/activejob/trackable/throttled_test.rb
@@ -24,7 +24,7 @@ module ActiveJob::Trackable
       end
     end
 
-    test 'throttling with a longer period than the job schedule' do
+    test 'throttling period is counted from when the job is scheduled to run at' do
       tracker = travel_to(now) { assert_tracked { schedule_job.tracker } }
 
       travel_to 1.hour.since(now) - 1.second do
@@ -42,11 +42,15 @@ module ActiveJob::Trackable
         end
       end
 
-      travel_to 1.day.since(now) - 1.second do
+      travel_to 1.day.since(now) do
         refute_job_enqueued do schedule_job end
       end
 
-      travel_to 1.day.since(now) do
+      travel_to 1.day.since(1.hour.since(now)) - 1.second do
+        refute_job_enqueued do schedule_job end
+      end
+
+      travel_to 1.day.since(1.hour.since(now)) do
         assert_tracked do schedule_job end
       end
     end

--- a/test/dummy/app/jobs/throttled_debounced_job.rb
+++ b/test/dummy/app/jobs/throttled_debounced_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ThrottledDebouncedJob < ApplicationJob
+  include ActiveJob::Trackable::Debounced
+
+  trackable throttled: 1.day
+
+  def perform(*arguments); end
+
+  private
+
+    def key(foo, _extra)
+      "foo-#{foo}"
+    end
+end


### PR DESCRIPTION
- debouncing a throttled job should reset the throttling period
- throttle period should be counted from when the job is scheduled
  to run instead of when the job is queued