### PR TITLE
add missing instalation instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ Or install it yourself as:
 $ gem install activejob-trackable
 ```
 
+run the generator:
+
+```ruby
+rails generate active_job:trackable
+```
+
+and run the generated migration:
+
+```ruby
+rake db:migrate
+```
+
 ## Contributing
 
 Any and all kind of help are welcomed! Especially interested in:


### PR DESCRIPTION
generator+migration need to be run during installation to prepare for the table used for storing traker records